### PR TITLE
Allow generation of possibly invalid modules

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -662,10 +662,17 @@ impl Module {
                         self.encode_val_type(bytes, *l);
                     });
 
-                    for inst in &code.instructions {
-                        self.encode_instruction(bytes, inst);
+                    match &code.instructions {
+                        Instructions::Generated(instrs) => {
+                            for inst in instrs {
+                                self.encode_instruction(bytes, inst);
+                            }
+                            self.encode_instruction(bytes, &Instruction::End);
+                        }
+                        Instructions::Arbitrary(body) => {
+                            bytes.extend_from_slice(body);
+                        }
                     }
-                    self.encode_instruction(bytes, &Instruction::End);
                 });
             });
         });


### PR DESCRIPTION
This commit takes a technique the spidermonkey folks are doing which is
to use the fuzz input as the raw body of a function. Currently many
fuzzers use the raw fuzz input as the entire wasm module, but that makes
it difficult to structure a valid wasm module because of section sizes
and such. The hope is that by simply using arbitrary fuzz input for the
instruction stream we can test more edge cases in the wasm decoder.

The changes here are to, for each function, use the fuzz input to
indicate whether a valid instruction stream is generated or a random one
is used. Modules now have a flag indicating whether they're guaranteed
valid modules (only procedurally generated functions).

One caveat is that for not-guaranteed-valid modules the
`ensure_termination` method no longer works, so wasm runtimes will need
some other method of cancelling execution while it's going.