### PR TITLE
Optimize call_valid and global_set_valid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ impl Arbitrary for FuncType {
     }
 }
 
-#[derive(Arbitrary, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Arbitrary, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 enum ValType {
     I32,
     I64,
@@ -663,7 +663,7 @@ impl Module {
 
     fn arbitrary_code(&mut self, u: &mut Unstructured) -> Result<()> {
         self.code.reserve(self.funcs.len());
-        let mut allocs = CodeBuilderAllocations::default();
+        let mut allocs = CodeBuilderAllocations::new(self);
         for ty in &self.funcs {
             let ty = &self.types[*ty as usize];
             let body = self.arbitrary_func_body(u, ty, &mut allocs)?;


### PR DESCRIPTION
This fixes an issue of generating modules taking a very long time with
lots of globals and lots of functions. The problem is that the
`global_set_valid` and `call_valid` filters were taking a very long time
because they kept iterating all globals/functions to see if the relevant
types were on the stack. The fix here is to precalculate information
about the module to gather globals/functions based on type first, then
use that to see if the right types are on the stack. This makes a
previous test case that took ~30s to generate a module locally (in
sanitized release mode) take a few milliseconds afterwards.