### PR TITLE
Ensure that globals aren't initialized with mutable globals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,7 +627,7 @@ where
             for (_, _, imp) in &self.imports {
                 match imp {
                     Import::Global(g) => {
-                        if g.val_type == ty.val_type {
+                        if !g.mutable && g.val_type == ty.val_type {
                             choices
                                 .push(Box::new(move |_, _| Ok(Instruction::GlobalGet(global_idx))));
                         }


### PR DESCRIPTION
Globals must be const if used in an initializer.

Fixes #18