### PR TITLE
Add support for memory-related bulk-memory instructions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,14 @@ jobs:
       - run: cargo fuzz build validate --sanitizer none
       - run: cargo fuzz run validate --sanitizer none -- -max_total_time=60
 
+  validate_swarm_fuzz_target:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cargo install cargo-fuzz
+      - run: cargo fuzz build validate-swarm --sanitizer none
+      - run: cargo fuzz run validate-swarm --sanitizer none -- -max_total_time=60
+
   validate_ensure_terminated_fuzz_target:
     runs-on: ubuntu-latest
     steps:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,3 +25,9 @@ name = "validate-ensure-termination"
 path = "fuzz_targets/validate-ensure-termination.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "validate-swarm"
+path = "fuzz_targets/validate-swarm.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/validate-swarm.rs
+++ b/fuzz/fuzz_targets/validate-swarm.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use wasm_smith::{Config, ConfiguredModule, SwarmConfig};
+
+fuzz_target!(|m: ConfiguredModule<SwarmConfig>| {
+    let bytes = m.to_bytes();
+
+    let mut validator = wasmparser::Validator::new();
+    validator.wasm_features(wasmparser::WasmFeatures {
+        multi_value: true,
+        bulk_memory: m.config().bulk_memory_enabled(),
+        multi_memory: m.config().max_memories() > 1,
+        ..wasmparser::WasmFeatures::default()
+    });
+    if let Err(e) = validator.validate_all(&bytes) {
+        std::fs::write("test.wasm", bytes).unwrap();
+        panic!("Invalid module: {}", e);
+    }
+});

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,12 @@ pub trait Config: Arbitrary + Default {
     fn min_uleb_size(&self) -> u8 {
         1
     }
+
+    /// Determines whether the bulk memory proposal is enabled for generating
+    /// insructions. Defaults to `false`.
+    fn bulk_memory_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// The default configuration.
@@ -133,6 +139,7 @@ pub struct SwarmConfig {
     max_instructions: usize,
     max_memories: u32,
     min_uleb_size: u8,
+    bulk_memory_enabled: bool,
 }
 
 impl Arbitrary for SwarmConfig {
@@ -147,8 +154,9 @@ impl Arbitrary for SwarmConfig {
             max_elements: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_data_segments: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_instructions: u.int_in_range(0..=MAX_MAXIMUM)?,
-            max_memories: u.int_in_range(0..=(MAX_MAXIMUM as u32))?,
+            max_memories: u.int_in_range(0..=100)?,
             min_uleb_size: u.int_in_range(0..=5)?,
+            bulk_memory_enabled: u.arbitrary()?,
         })
     }
 }
@@ -192,5 +200,9 @@ impl Config for SwarmConfig {
 
     fn min_uleb_size(&self) -> u8 {
         self.min_uleb_size
+    }
+
+    fn bulk_memory_enabled(&self) -> bool {
+        self.bulk_memory_enabled
     }
 }


### PR DESCRIPTION
This commit adds support for some new instructions:

* `data.drop`
* `memory.init`
* `memory.copy`
* `memory.fill`

This also adds support for passive data and the data count section. A
new `Config::bulk_memory_enabled` boolean, defaulting to `false`, is
added which gates all of this support. Finally the generation of data
segments was moved before the code so we know whether `data.drop` will
be valid by the time we're generating code.

Finally, a new fuzz target was added which validates all possible
modules (generated by `SwarmConfig`) with `wasmparser`.